### PR TITLE
Disable IPv6 inside environment by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
 
       - ARGUS_DATAPORTEN_KEY=notset
       - ARGUS_DATAPORTEN_SECRET=notset
+    # Disable IPv6 to avoid slow DB connection setup. Docker may assign IPv6
+    # addresses to containers but not route traffic correctly, causing libpq to
+    # timeout on IPv6 before falling back to IPv4 on every request.
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
 
   postgres:
     image: "postgres:14"


### PR DESCRIPTION
My Docker stack enables IPv6 because I need it, but apparently, this caused massive problems in argus-docker:

Resolving the `postgres` container name would return both an IPv6 and an IPv4 address, since it had been assigned both.  Django/psycopg appears to default to try to connect to the IPv6 address first, but apparently, the api container was not able to connect to the postgres container using the IPv6 stack.  This attempt would in turn time out, and only then would the driver fall back to attempt an IPv4 connection, successfully.

Coupled with the fact that Argus uses the Django configuration default of disconnecting/reconnecting to the database between requests, this behavior caused massive delays in request handling: Most requests would take 3 seconds to process because of the database connection timeout issue, causing massive delays when syncing large amounts of incidents.

IPv6 is not essential to internal communication within this docker-compose environment, so the quick fix is just to disable IPv6 networking by default in the `api` container.  These files are mostly to test Argus quickly and easily, or to use as examples for deploying in your own production systems, and we would expect users to tweak their settings if they require IPv6 anyway.