### PR TITLE
Refresh deployment docs and drop dead env vars

### DIFF
--- a/.env
+++ b/.env
@@ -20,4 +20,13 @@ POSTGRES_PASSWORD=GeeGhee8Ohng
 
 # Default URLs and ports
 ARGUS_BACKEND_PORT=8000
+
+# The canonical, publicly visible base URL of this Argus instance. Argus uses it
+# to build absolute links *back into itself* - e.g. the incident permalinks
+# embedded in auto-created tickets. It must therefore match the address users
+# actually reach Argus at, including scheme and (non-default) port: get it wrong
+# and those links point somewhere users cannot follow. In production behind a
+# TLS-terminating proxy this should be the real https:// URL. Note that on this
+# localhost test setup the app is browsed at :${ARGUS_BACKEND_PORT}, which the
+# value below does not include.
 ARGUS_FRONTEND_URL=http://${ARGUS_DOMAIN}

--- a/README.md
+++ b/README.md
@@ -18,16 +18,23 @@ This repository contains a simple, but complete Argus deployment example using
    This should create the `admin` user and print a randomly generated password for
    that user. Use this on your first login to Argus.
 
-3. Browse http://localhost/
+3. Browse http://localhost:8000/
 
 ## More details
 
 ### Services
 
-This docker compose environment brings up two services:
+This docker compose environment brings up three services:
 
-1. [Argus - API and frontend](https://github.com/Uninett/Argus) (http port 8000)
-2. A PostgreSQL server for persistent storage of Argus data
+1. [Argus](https://github.com/Uninett/Argus) (`api`), which serves both the web
+   interface and the REST API on http port 8000. Since Argus 2.0 the web
+   frontend is rendered server-side and bundled into this single image — there
+   is no longer a separate frontend application to deploy.
+2. A background task worker (`db-task-queue`), running from the same Argus image
+   with an alternate command. It drains the database-backed task queue that
+   delivers notifications; without it Argus runs, but never sends any
+   notifications.
+3. A PostgreSQL server for persistent storage of Argus data.
 
 ### Configuration
 
@@ -35,27 +42,90 @@ Minimally, you need to alter the configuration in the [`.env`](./.env) file to s
 setup (including generating the keys/random strings that should be unique for
 your site!).
 
-If you are just testing on `localhost`, the existing settings are mostly fine. Be
-aware that the complete application consists of *2 web sites*:
+If you are just testing on `localhost`, the existing settings are mostly fine.
 
-1. The frontend, pre-configured at build time to access the backend at the
-   configured domain name.
-2. The backend API server.
+#### Changing the port number
 
-#### Changing port numbers
+By default, Argus binds to your system's port *8000*. If you wish to change
+this, set the `ARGUS_BACKEND_PORT` variable in [`.env`](./.env).
 
-By default, the frontend service (which you normally visit using your browser)
-is configured to bind to your system's port *80*, while the backend is bound to
-port *8000*. If you, for some reason, wish to change this, set the
-`ARGUS_FRONTEND_PORT` and `ARGUS_BACKEND_PORT` variables in [`.env`](./.env).
+### TLS / HTTPS
 
-### SSL
+This example serves Argus over plain HTTP and does **not** terminate TLS, which
+is fine for local testing but unacceptable for production. TLS is normally
+handled by a reverse proxy placed in front of the `api` service. For a Docker
+Compose setup, a convenient option is to add
+[nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) together with its
+[acme-companion](https://github.com/nginx-proxy/acme-companion) (for automatic
+Let's Encrypt certificates), preferably wired in through your own
+`docker-compose.override.yml` so the base `docker-compose.yml` stays
+deployment-agnostic.
 
-This setup does not include SSL protection of the web sites. This is absolutely
-necessary for production deployment. If you want to deploy to production user
-Docker Compose, we suggest looking at including
-https://github.com/nginx-proxy/acme-companion into your `docker-compose.yml`
-(or maybe preferably, into `docker-compose.override.yml`).
+Once TLS is in place, set `ARGUS_FRONTEND_URL` in [`.env`](./.env) to the public
+`https://` URL, so the permalinks Argus embeds in tickets and notifications use
+the correct scheme and hostname.
+
+### Authentication and federated login
+
+Out of the box Argus uses local accounts: the `initial_setup` step above creates
+the `admin` user, and further users can be added through Django's admin at
+`/admin/` or via the API. For production you will usually want to connect Argus
+to your organisation's identity provider instead. Argus supports two broad
+approaches:
+
+* **Web-server / `REMOTE_USER`** — the reverse proxy authenticates the user (for
+  example SAML via Apache `mod_auth_mellon` or an nginx SAML module) and passes
+  the username to Argus.
+* **In-process OAuth2 / OIDC** via
+  [python-social-auth](https://github.com/python-social-auth) — this is what Sikt
+  uses for Feide/Dataporten.
+
+Both require installing extra Python packages and supplying a custom Django
+settings module, so they are intentionally left out of this minimal example. See
+[How to add federated login](https://argus-server.readthedocs.io/en/latest/development/howtos/federated-logins.html)
+and the
+[authentication reference](https://argus-server.readthedocs.io/en/latest/reference/authentication.html)
+for the details.
+
+### Notification and ticket-system plugins
+
+The default `ghcr.io/uninett/argus` image bundles Argus's built-in notification
+media — as of 2.9.1 that is email, an email-based SMS plugin, and Slack (incoming
+webhooks) — with only email enabled out of the box. (The built-in set can grow
+between releases, so on a newer image check the notification docs linked below.)
+Other integrations ship as separate Python packages installed alongside Argus:
+
+* **Notification plugins** (e.g. Microsoft Teams) deliver notifications to
+  additional destinations. See
+  [Notification plugins](https://argus-server.readthedocs.io/en/latest/integrations/notifications/index.html).
+* **Ticket-system plugins** (GitHub, GitLab, Jira and Request Tracker) let Argus
+  automatically create tickets from incidents. See
+  [Ticket system plugins](https://argus-server.readthedocs.io/en/latest/integrations/ticket-systems/index.html).
+
+Rather than building a custom image to add these packages, you can switch to the
+**all-plugins** image, which is built from the same releases and ships with every
+Sikt-maintained notification and ticket plugin pre-installed:
+
+```
+ghcr.io/uninett/argus-all-plugins:<version>
+```
+
+This image is published from Argus **2.9.1** onward and carries the same version
+tags as the default image, so pick a tag that actually exists (2.9.1 or newer —
+note the example in this repo still pins an older `api` image). Switch to it by
+changing the `image:` field in the `x-argus` anchor in
+[`docker-compose.yml`](./docker-compose.yml) (or overriding it in
+`docker-compose.override.yml`). Both the `api` and `db-task-queue` services share
+that anchor, so the change covers both — which matters, because the worker is the
+service that actually sends notifications.
+
+Note that **installed is not the same as activated**: whichever image you use,
+plugins must still be enabled and configured through Argus settings —
+`MEDIA_PLUGINS` for notification media, and `TICKET_PLUGIN` / `TICKET_ENDPOINT` /
+`TICKET_AUTHENTICATION_SECRET` / `TICKET_INFORMATION` for ticketing — which means
+supplying a custom settings module. See
+[site-specific settings](https://argus-server.readthedocs.io/en/latest/reference/site-specific-settings.html)
+and the integration pages above for the specifics.
 
 ### Troubleshooting on MacOS
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,8 @@ x-argus: &argus-service
     - TIME_ZONE=${TIME_ZONE}
     - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}
     - ARGUS_FRONTEND_URL=${ARGUS_FRONTEND_URL}
-    - STATIC_ROOT=static/
     - EMAIL_HOST=${EMAIL_HOST}
     - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL}
-    - ARGUS_DATAPORTEN_KEY=notset
-    - ARGUS_DATAPORTEN_SECRET=notset
 
 services:
   api:


### PR DESCRIPTION
Builds on #54 (the 2.9.1 bump). Brings the example's docs in line with Argus since the 2.0 frontend consolidation, and removes config the image no longer reads.

- Corrects the README's stale references to a separate frontend and a port-80 site (it's one service on 8000 now), and documents the `db-task-queue` worker.
- Adds guidance for extending the example: TLS via a reverse proxy, federated login (OAuth2/OIDC or `REMOTE_USER`/SAML), and notification/ticket plugins (incl. the `argus-all-plugins` image), linking the relevant argus-server.readthedocs.io pages.
- Drops `STATIC_ROOT` (the image sets it to `/static`) and the `ARGUS_DATAPORTEN_*` vars (dead since the React frontend was removed in 2.0).

No functional change beyond the inherited 2.9.1 bump — the dropped vars were inert.
